### PR TITLE
Tests: add setup config ci

### DIFF
--- a/.github/scripts/setup-config.py
+++ b/.github/scripts/setup-config.py
@@ -1,0 +1,47 @@
+import json
+import os
+from pathlib import Path
+import tomlkit
+
+CONFIG_FOLDER = Path.home() / ".basedosdados"
+CREDENTIALS_FOLDER = CONFIG_FOLDER / "credentials"
+
+
+def setup():
+    if not os.path.exists(CREDENTIALS_FOLDER):
+        os.makedirs(CREDENTIALS_FOLDER)
+        print(f"{CREDENTIALS_FOLDER} folder created")
+
+    config_toml = {
+        "bucket_name": "basedosdados-dev",
+        "api": {"url": "https://staging.backend.basedosdados.org/api/v1/graphql"},
+        "gcloud-projects": {
+            "prod": {
+                "credentials_path": (CREDENTIALS_FOLDER / "prod.json").as_posix(),
+                "name": "basedosdados-dev",
+            },
+            "staging": {
+                "credentials_path": (CREDENTIALS_FOLDER / "staging.json").as_posix(),
+                "name": "basedosdados-dev",
+            },
+        },
+    }
+
+    with open(CONFIG_FOLDER / "config.toml", "w") as io:
+        tomlkit.dump(config_toml, io)
+
+    google_credentials = os.getenv("GOOGLE_CREDENTIALS")
+
+    assert isinstance(google_credentials, str)
+
+    credentials_json = json.loads(google_credentials)
+
+    with open(CREDENTIALS_FOLDER / "prod.json", "w", encoding="utf-8") as f:
+        json.dump(credentials_json, f, ensure_ascii=False, indent=2)
+
+    with open(CREDENTIALS_FOLDER / "staging.json", "w", encoding="utf-8") as f:
+        json.dump(credentials_json, f, ensure_ascii=False, indent=2)
+
+
+if __name__ == "__main__":
+    setup()

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Install poetry
         run: pipx install poetry
 
+      # https://github.com/python-poetry/poetry/issues/2117
       - name: Set Poetry environment
         run: poetry env use '${{ steps.python.outputs.python-path }}'
         working-directory: python-package
@@ -37,6 +38,12 @@ jobs:
       - name: Install requirements
         run: poetry install --with dev --all-extras --no-root
         working-directory: python-package
+
+      - name: Setup config
+        env:
+          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+        working-directory: python-package
+        run: poetry run python ../.github/scripts/setup-config.py
 
       - name: Test (python-${{ matrix.python-version }}, ${{ matrix.os }})
         run: poetry run pytest

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Setup config
         env:
-          GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+          GOOGLE_CREDENTIALS: ${{ secrets.GCP_BD_PROD }}
         working-directory: python-package
         run: poetry run python ../.github/scripts/setup-config.py
 


### PR DESCRIPTION
Precisamos de uma secret `GOOGLE_CREDENTIALS` com a chave da conta de serviço para executar os testes.