### PR TITLE
backend: add headers and client param

### DIFF
--- a/python-package/basedosdados/backend.py
+++ b/python-package/basedosdados/backend.py
@@ -496,6 +496,12 @@ class Backend(metaclass=SingletonMeta):
         Returns:
             Dict: GraphQL response.
         """
+        if not _backend_dependencies:
+            raise BaseDosDadosMissingDependencyException(
+                "Optional dependencies for backend interaction are not installed. "
+                'Please install basedosdados with the "upload" extra, such as:'
+                "\n\npip install basedosdados[upload]"
+            )
 
         client_ = (
             self._get_client(


### PR DESCRIPTION
Esses dois parâmetros estavam presente na versão beta 5. Foi removido por algum motivo impossibilitando fazer mutações já que não podemos passar o username e password no header para pegar o token

Em pipelines usamos para atualizar os metadados https://github.com/basedosdados/pipelines/blob/ad1656be51e3502bb4d6afbf6b48627c1eeac5a7/pipelines/utils/metadata/utils.py#L423